### PR TITLE
fix(docker): add binaryTargets to src/app.prisma

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,7 +8,7 @@
 //
 
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
   binaryTargets = ["debian-openssl-3.0.x", "debian-openssl-1.1.x"]
 }
 

--- a/src/app.prisma
+++ b/src/app.prisma
@@ -1,5 +1,6 @@
 generator client {
   provider = "prisma-client-js"
+  binaryTargets = ["debian-openssl-3.0.x", "debian-openssl-1.1.x"]
 }
 
 datasource db {


### PR DESCRIPTION
Allow binaryTargets to be automatically added by `pnpm build-prisma`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved database configuration for enhanced compatibility across different systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->