### PR TITLE
fix(ci): use migrate instead of db push

### DIFF
--- a/.github/workflows/build-test-docker-dev.yml
+++ b/.github/workflows/build-test-docker-dev.yml
@@ -58,8 +58,10 @@ jobs:
       - name: Start compose
         run: docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build -d
 
-      - name: Initialize Database Structures with Prisma
-        run: docker compose exec backend pnpm prisma db push
+      - name: Sync Database Structures with Prisma
+        run: |
+          docker compose exec backend pnpm prisma migrate resolve --applied 20240321040602_init
+          docker compose exec backend pnpm prisma migrate deploy
 
       - name: Run Test
         run: docker compose exec backend pnpm run test:cov


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the database initialization process in development environment to use Prisma migrations for better synchronization of database structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->