### PR TITLE
refactor: rename `XIdNotFoundError` to `XNotFoundError`

### DIFF
--- a/src/answer/answer.service.ts
+++ b/src/answer/answer.service.ts
@@ -14,7 +14,7 @@ import { CommentableType } from '../comments/commentable.enum';
 import { PageRespondDto } from '../common/DTO/page-respond.dto';
 import { PageHelper } from '../common/helper/page.helper';
 import { GroupsService } from '../groups/groups.service';
-import { QuestionIdNotFoundError } from '../questions/questions.error';
+import { QuestionNotFoundError } from '../questions/questions.error';
 import { QuestionsService } from '../questions/questions.service';
 import { UserIdNotFoundError } from '../users/users.error';
 import { User } from '../users/users.legacy.entity';
@@ -599,7 +599,7 @@ export class AnswerService {
 
   async countQuestionAnswers(questionId: number): Promise<number> {
     if ((await this.questionsService.isQuestionExists(questionId)) == false)
-      throw new QuestionIdNotFoundError(questionId);
+      throw new QuestionNotFoundError(questionId);
     return this.answerRepository.countBy({
       questionId: questionId,
     });

--- a/src/comments/comment.error.ts
+++ b/src/comments/comment.error.ts
@@ -7,7 +7,7 @@ export class CommentableNotFoundError extends BaseError {
     public readonly commentableId: number,
   ) {
     super(
-      'CommentableIdNotFoundError',
+      'CommentableNotFoundError',
       `${commentableType} ${commentableId} not found`,
       404,
     );

--- a/src/groups/groups.error.ts
+++ b/src/groups/groups.error.ts
@@ -32,9 +32,9 @@ export class GroupNameAlreadyUsedError extends BaseError {
   }
 }
 
-export class GroupIdNotFoundError extends BaseError {
+export class GroupNotFoundError extends BaseError {
   constructor(public readonly groupId: number) {
-    super('GroupIdNotFoundError', `Group with id ${groupId} not found`, 404);
+    super('GroupNotFoundError', `Group with id ${groupId} not found`, 404);
   }
 }
 

--- a/src/groups/groups.service.ts
+++ b/src/groups/groups.service.ts
@@ -15,7 +15,7 @@ import { AvatarNotFoundError } from '../avatars/avatars.error';
 import { AvatarsService } from '../avatars/avatars.service';
 import { PageRespondDto } from '../common/DTO/page-respond.dto';
 import { PageHelper } from '../common/helper/page.helper';
-import { QuestionIdNotFoundError } from '../questions/questions.error';
+import { QuestionNotFoundError } from '../questions/questions.error';
 import { QuestionsService } from '../questions/questions.service';
 import { UserDto } from '../users/DTO/user.dto';
 import { UserIdNotFoundError } from '../users/users.error';
@@ -27,8 +27,8 @@ import { GroupProfile } from './group-profile.entity';
 import {
   CannotDeleteGroupError,
   GroupAlreadyJoinedError,
-  GroupIdNotFoundError,
   GroupNameAlreadyUsedError,
+  GroupNotFoundError,
   GroupNotJoinedError,
   GroupProfileNotFoundError,
   InvalidGroupNameError,
@@ -172,7 +172,7 @@ export class GroupsService {
         id: page_start_id,
       });
       if (!referenceGroup) {
-        throw new GroupIdNotFoundError(page_start_id);
+        throw new GroupNotFoundError(page_start_id);
       }
 
       let referenceValue;
@@ -262,7 +262,7 @@ export class GroupsService {
       relations: ['profile'],
     });
     if (group == undefined) {
-      throw new GroupIdNotFoundError(groupId);
+      throw new GroupNotFoundError(groupId);
     }
 
     const ownership = await this.groupMembershipsRepository.findOneBy({
@@ -331,7 +331,7 @@ export class GroupsService {
       relations: ['profile'],
     });
     if (group == undefined) {
-      throw new GroupIdNotFoundError(groupId);
+      throw new GroupNotFoundError(groupId);
     }
 
     const userMembership = await this.groupMembershipsRepository.findOneBy({
@@ -367,7 +367,7 @@ export class GroupsService {
       relations: ['profile'],
     });
     if (group == undefined) {
-      throw new GroupIdNotFoundError(groupId);
+      throw new GroupNotFoundError(groupId);
     }
 
     const owner = await this.groupMembershipsRepository.findOneBy({
@@ -392,7 +392,7 @@ export class GroupsService {
   ): Promise<JoinGroupResultDto> {
     const group = await this.groupsRepository.findOneBy({ id: groupId });
     if (group == undefined) {
-      throw new GroupIdNotFoundError(groupId);
+      throw new GroupNotFoundError(groupId);
     }
 
     if (
@@ -421,7 +421,7 @@ export class GroupsService {
   async quitGroup(userId: number, groupId: number): Promise<number> {
     const group = await this.groupsRepository.findOneBy({ id: groupId });
     if (group == undefined) {
-      throw new GroupIdNotFoundError(groupId);
+      throw new GroupNotFoundError(groupId);
     }
 
     const membership = await this.groupMembershipsRepository.findOneBy({
@@ -449,7 +449,7 @@ export class GroupsService {
     page_size: number,
   ): Promise<[UserDto[], PageRespondDto]> {
     if ((await this.groupsRepository.findOneBy({ id: groupId })) == undefined) {
-      throw new GroupIdNotFoundError(groupId);
+      throw new GroupNotFoundError(groupId);
     }
 
     if (!firstMemberId) {
@@ -519,7 +519,7 @@ export class GroupsService {
           questionId: page_start_id,
         });
       if (!referenceRelationship) {
-        throw new QuestionIdNotFoundError(page_start_id);
+        throw new QuestionNotFoundError(page_start_id);
       }
       const referenceValue = referenceRelationship.createdAt;
       const prev = await this.groupQuestionRelationshipsRepository

--- a/src/questions/questions.error.ts
+++ b/src/questions/questions.error.ts
@@ -9,13 +9,9 @@
 
 import { BaseError } from '../common/error/base-error';
 export const BOUNTY_LIMIT = 20;
-export class QuestionIdNotFoundError extends BaseError {
+export class QuestionNotFoundError extends BaseError {
   constructor(id: number) {
-    super(
-      'QuestionIdNotFoundError',
-      `Question with id ${id} is not found.`,
-      404,
-    );
+    super('QuestionNotFoundError', `Question with id ${id} is not found.`, 404);
   }
 }
 
@@ -39,10 +35,10 @@ export class QuestionNotFollowedYetError extends BaseError {
   }
 }
 
-export class QuestionInvitationIdNotFoundError extends BaseError {
+export class QuestionInvitationNotFoundError extends BaseError {
   constructor(id: number) {
     super(
-      'QuestionInvitationIdNotFoundError',
+      'QuestionInvitationNotFoundError',
       `Question invitation with id ${id} is not found.`,
       400,
     );

--- a/src/questions/questions.spec.ts
+++ b/src/questions/questions.spec.ts
@@ -12,7 +12,7 @@ import { TopicNotFoundError } from '../topics/topics.error';
 import { TopicsService } from '../topics/topics.service';
 import { UserIdNotFoundError } from '../users/users.error';
 import { UsersService } from '../users/users.service';
-import { QuestionIdNotFoundError } from './questions.error';
+import { QuestionNotFoundError } from './questions.error';
 import { QuestionsService } from './questions.service';
 
 describe('Questions Module', () => {
@@ -93,10 +93,10 @@ describe('Questions Module', () => {
     ).rejects.toThrow(new UserIdNotFoundError(-1));
   });
 
-  it('should throw QuestionIdNotFoundError', async () => {
+  it('should throw QuestionNotFoundError', async () => {
     await expect(
       questionsService.addTopicToQuestion(-1, topicId1, 1),
-    ).rejects.toThrow(new QuestionIdNotFoundError(-1));
+    ).rejects.toThrow(new QuestionNotFoundError(-1));
   });
 
   it('should throw TopicNotFoundError', async () => {
@@ -111,15 +111,15 @@ describe('Questions Module', () => {
     ).rejects.toThrow(new UserIdNotFoundError(-1));
   });
 
-  it('should throw QuestionIdNotFoundError', async () => {
+  it('should throw QuestionNotFoundError', async () => {
     await expect(
       questionsService.updateQuestion(-1, 'title', 'content', 0, [], 1),
-    ).rejects.toThrow(new QuestionIdNotFoundError(-1));
+    ).rejects.toThrow(new QuestionNotFoundError(-1));
     await expect(questionsService.deleteQuestion(-1)).rejects.toThrow(
-      new QuestionIdNotFoundError(-1),
+      new QuestionNotFoundError(-1),
     );
     await expect(questionsService.unfollowQuestion(1, -1)).rejects.toThrow(
-      new QuestionIdNotFoundError(-1),
+      new QuestionNotFoundError(-1),
     );
   });
 });

--- a/test/comment.e2e-spec.ts
+++ b/test/comment.e2e-spec.ts
@@ -238,7 +238,7 @@ describe('comments Module', () => {
           content: `${TestCommentPrefix} ${content}`,
         });
 
-      expect(respond.body.message).toMatch(/^CommentableIdNotFoundError: /);
+      expect(respond.body.message).toMatch(/^CommentableNotFoundError: /);
       expect(respond.body.code).toBe(404);
       expect(respond.status).toBe(404);
     });

--- a/test/groups.e2e-spec.ts
+++ b/test/groups.e2e-spec.ts
@@ -421,12 +421,12 @@ describe('Groups Module', () => {
       expect(groupDto.is_owner).toBe(false);
     });
 
-    it('should return GroupIdNotFoundError when group is not found', async () => {
+    it('should return GroupNotFoundError when group is not found', async () => {
       const respond = await request(app.getHttpServer())
         .get(`/groups/0`)
         .set('Authorization', `Bearer ${TestToken}`)
         .send();
-      expect(respond.body.message).toMatch(/^GroupIdNotFoundError: /);
+      expect(respond.body.message).toMatch(/^GroupNotFoundError: /);
       expect(respond.status).toBe(404);
       expect(respond.body.code).toBe(404);
     });
@@ -469,12 +469,12 @@ describe('Groups Module', () => {
       expect(groupDto.is_member).toBe(true);
       expect(groupDto.is_owner).toBe(false);
     });
-    it('should return GroupIdNotFoundError when group is not found', async () => {
+    it('should return GroupNotFoundError when group is not found', async () => {
       const respond = await request(app.getHttpServer())
         .post(`/groups/0/members`)
         .set('Authorization', `Bearer ${auxAccessToken}`)
         .send({ intro: '我是初音未来' });
-      expect(respond.body.message).toMatch(/^GroupIdNotFoundError: /);
+      expect(respond.body.message).toMatch(/^GroupNotFoundError: /);
       expect(respond.status).toBe(404);
       expect(respond.body.code).toBe(404);
     });
@@ -528,7 +528,7 @@ describe('Groups Module', () => {
       expect(groupDto.is_member).toBe(true);
       expect(groupDto.is_owner).toBe(false);
     });
-    it('should return GroupIdNotFoundError when group is not found', async () => {
+    it('should return GroupNotFoundError when group is not found', async () => {
       const respond = await request(app.getHttpServer())
         .put('/groups/0')
         .set('Authorization', `Bearer ${TestToken}`)
@@ -539,7 +539,7 @@ describe('Groups Module', () => {
         });
       expect(respond.status).toBe(404);
       expect(respond.body.code).toBe(404);
-      expect(respond.body.message).toMatch(/^GroupIdNotFoundError: /);
+      expect(respond.body.message).toMatch(/^GroupNotFoundError: /);
     });
     it('should return GroupNameAlreadyUsedError when group name is already used', async () => {
       const TestGroupId = GroupIds[0];
@@ -606,12 +606,12 @@ describe('Groups Module', () => {
       expect(groupDto.is_member).toBe(false);
       expect(groupDto.is_owner).toBe(false);
     });
-    it('should return GroupIdNotFoundError when group is not found', async () => {
+    it('should return GroupNotFoundError when group is not found', async () => {
       const respond = await request(app.getHttpServer())
         .delete(`/groups/0/members`)
         .set('Authorization', `Bearer ${auxAccessToken}`)
         .send();
-      expect(respond.body.message).toMatch(/^GroupIdNotFoundError: /);
+      expect(respond.body.message).toMatch(/^GroupNotFoundError: /);
       expect(respond.status).toBe(404);
       expect(respond.body.code).toBe(404);
     }, 10000);
@@ -637,22 +637,22 @@ describe('Groups Module', () => {
         .send();
       expect(respond.status).toBe(200);
     });
-    it('should return GroupIdNotFoundError after deletion', async () => {
+    it('should return GroupNotFoundError after deletion', async () => {
       const TestGroupId = GroupIds[3];
       const respond = await request(app.getHttpServer())
         .get(`/groups/${TestGroupId}`)
         .set('Authorization', `Bearer ${TestToken}`)
         .send();
-      expect(respond.body.message).toMatch(/^GroupIdNotFoundError: /);
+      expect(respond.body.message).toMatch(/^GroupNotFoundError: /);
       expect(respond.status).toBe(404);
       expect(respond.body.code).toBe(404);
     });
-    it('should return GroupIdNotFoundError when group is not found', async () => {
+    it('should return GroupNotFoundError when group is not found', async () => {
       const respond = await request(app.getHttpServer())
         .delete(`/groups/0`)
         .set('Authorization', `Bearer ${TestToken}`)
         .send();
-      expect(respond.body.message).toMatch(/^GroupIdNotFoundError: /);
+      expect(respond.body.message).toMatch(/^GroupNotFoundError: /);
       expect(respond.status).toBe(404);
       expect(respond.body.code).toBe(404);
     });
@@ -744,12 +744,12 @@ describe('Groups Module', () => {
       expect(respond.body.data.page.has_more).toBe(false);
       expect(respond.body.data.page.next_start).toBeFalsy();
     });
-    it('should return GroupIdNotFoundError when group is not found', async () => {
+    it('should return GroupNotFoundError when group is not found', async () => {
       const respond = await request(app.getHttpServer())
         .get(`/groups/0/members`)
         .set('Authorization', `Bearer ${TestToken}`)
         .send();
-      expect(respond.body.message).toMatch(/^GroupIdNotFoundError: /);
+      expect(respond.body.message).toMatch(/^GroupNotFoundError: /);
       expect(respond.status).toBe(404);
       expect(respond.body.code).toBe(404);
     });

--- a/test/question.e2e-spec.ts
+++ b/test/question.e2e-spec.ts
@@ -295,12 +295,12 @@ describe('Questions Module', () => {
       expect(respond.body.data.question.comment_count).toBe(0);
       expect(respond.body.data.question.group).toBe(null);
     }, 20000);
-    it('should return QuestionIdNotFoundError', async () => {
+    it('should return QuestionNotFoundError', async () => {
       const respond = await request(app.getHttpServer())
         .get('/questions/-1')
         .set('Authorization', `Bearer ${TestToken}`)
         .send();
-      expect(respond.body.message).toMatch(/^QuestionIdNotFoundError: /);
+      expect(respond.body.message).toMatch(/^QuestionNotFoundError: /);
       expect(respond.body.code).toBe(404);
     });
   });
@@ -477,11 +477,11 @@ describe('Questions Module', () => {
       );
       expect(respond2.body.data.page.has_more).toBe(true);
     });
-    it('should return QuestionIdNotFoundError', async () => {
+    it('should return QuestionNotFoundError', async () => {
       const respond = await request(app.getHttpServer())
         .get(`/questions?q=${TestQuestionPrefix}&page_size=5&page_start=-1`)
         .send();
-      expect(respond.body.message).toMatch(/^QuestionIdNotFoundError: /);
+      expect(respond.body.message).toMatch(/^QuestionNotFoundError: /);
       expect(respond.body.code).toBe(404);
       expect(respond.status).toBe(404);
     });
@@ -531,7 +531,7 @@ describe('Questions Module', () => {
       expect(respond.body.message).toMatch(/^AuthenticationRequiredError: /);
       expect(respond.body.code).toBe(401);
     });
-    it('should return QuestionIdNotFoundError', async () => {
+    it('should return QuestionNotFoundError', async () => {
       const respond = await request(app.getHttpServer())
         .put('/questions/-1')
         .set('Authorization', `Bearer ${TestToken}`)
@@ -542,7 +542,7 @@ describe('Questions Module', () => {
           type: 1,
           topics: [TopicIds[2]],
         });
-      expect(respond.body.message).toMatch(/^QuestionIdNotFoundError: /);
+      expect(respond.body.message).toMatch(/^QuestionNotFoundError: /);
       expect(respond.body.code).toBe(404);
     });
     it('should return PermissionDeniedError', async () => {
@@ -570,12 +570,12 @@ describe('Questions Module', () => {
       expect(respond.body.message).toMatch(/^AuthenticationRequiredError: /);
       expect(respond.body.code).toBe(401);
     });
-    it('should return QuestionIdNotFoundError', async () => {
+    it('should return QuestionNotFoundError', async () => {
       const respond = await request(app.getHttpServer())
         .delete('/questions/-1')
         .set('Authorization', `Bearer ${TestToken}`)
         .send();
-      expect(respond.body.message).toMatch(/^QuestionIdNotFoundError: /);
+      expect(respond.body.message).toMatch(/^QuestionNotFoundError: /);
       expect(respond.body.code).toBe(404);
     });
     it('should return PermissionDeniedError', async () => {
@@ -595,7 +595,7 @@ describe('Questions Module', () => {
       const respond2 = await request(app.getHttpServer())
         .get(`/questions/${questionIds[0]}`)
         .send();
-      expect(respond2.body.message).toMatch(/^QuestionIdNotFoundError: /);
+      expect(respond2.body.message).toMatch(/^QuestionNotFoundError: /);
       expect(respond2.body.code).toBe(404);
     });
   });
@@ -737,12 +737,12 @@ describe('Questions Module', () => {
       expect(respond.body.data.questions.length).toBe(1);
       expect(respond.body.data.questions[0].id).toBe(questionIds[2]);
     });
-    it('should return QuestionIdNotFoundError', async () => {
+    it('should return QuestionNotFoundError', async () => {
       const respond = await request(app.getHttpServer())
         .post(`/questions/${questionIds[0]}/followers`)
         .set('Authorization', `Bearer ${TestToken}`)
         .send();
-      expect(respond.body.message).toMatch(/^QuestionIdNotFoundError: /);
+      expect(respond.body.message).toMatch(/^QuestionNotFoundError: /);
       expect(respond.body.code).toBe(404);
       expect(respond.status).toBe(404);
     });
@@ -1072,12 +1072,12 @@ describe('Questions Module', () => {
       expect(respond.body.message).toContain('UserIdNotFoundError');
       expect(respond.body.code).toBe(404);
     });
-    it('should return QuestionIdNotFoundError', async () => {
+    it('should return QuestionNotFoundError', async () => {
       const respond = await request(app.getHttpServer())
         .post(`/questions/114514/invitations`)
         .set('Authorization', `Bearer ${TestToken}`)
         .send({ user_id: TestUserId });
-      expect(respond.body.message).toContain('QuestionIdNotFoundError');
+      expect(respond.body.message).toContain('QuestionNotFoundError');
       expect(respond.body.code).toBe(404);
     });
 
@@ -1275,29 +1275,29 @@ describe('Questions Module', () => {
         .set('Authorization', `Bearer ${TestToken}`)
         .send();
       expect(respond.body.message).toMatch(
-        /^QuestionInvitationIdNotFoundError: /,
+        /^QuestionInvitationNotFoundError: /,
       );
       expect(respond.body.code).toBe(400);
       expect(respond.status).toBe(400);
     });
-    it('should return QuestionInvitationIdNotFoundError', async () => {
+    it('should return QuestionInvitationNotFoundError', async () => {
       const respond = await request(app.getHttpServer())
         .delete(`/questions/${questionIds[1]}/invitations/1919818`)
         .set('Authorization', `Bearer ${TestToken}`)
         .send();
       expect(respond.body.message).toMatch(
-        /^QuestionInvitationIdNotFoundError: /,
+        /^QuestionInvitationNotFoundError: /,
       );
       expect(respond.body.code).toBe(400);
       expect(respond.status).toBe(400);
     });
-    it('should return QuestionIdNotFoundError', async () => {
+    it('should return QuestionNotFoundError', async () => {
       const questionId = 1234567;
       const respond = await request(app.getHttpServer())
         .delete(`/questions/${questionId}/invitations/${invitationIds[1]}`)
         .set('Authorization', `Bearer ${TestToken}`)
         .send();
-      expect(respond.body.message).toContain('QuestionIdNotFoundError');
+      expect(respond.body.message).toContain('QuestionNotFoundError');
       expect(respond.body.code).toBe(404);
       expect(respond.status).toBe(404);
     });
@@ -1312,23 +1312,21 @@ describe('Questions Module', () => {
       expect(respond.body.data.invitation.id).toBe(invitationIds[1]);
       expect(respond.body.code).toBe(200);
     });
-    it('should return QuestionIdNotFoundError', async () => {
+    it('should return QuestionNotFoundError', async () => {
       const questionId = 1234567;
       const respond = await request(app.getHttpServer())
         .get(`/questions/${questionId}/invitations/${invitationIds[1]}`)
         .set('Authorization', `Bearer ${TestToken}`)
         .send();
-      expect(respond.body.message).toContain('QuestionIdNotFoundError');
+      expect(respond.body.message).toContain('QuestionNotFoundError');
       expect(respond.body.code).toBe(404);
       expect(respond.status).toBe(404);
     });
-    it('should return QuestionInvitationIdNotFoundError', async () => {
+    it('should return QuestionInvitationNotFoundError', async () => {
       const respond = await request(app.getHttpServer())
         .get(`/questions/${questionIds[1]}/invitations/${invitationIds[0]}`)
         .set('Authorization', `Bearer ${TestToken}`);
-      expect(respond.body.message).toContain(
-        'QuestionInvitationIdNotFoundError',
-      );
+      expect(respond.body.message).toContain('QuestionInvitationNotFoundError');
       expect(respond.body.code).toBe(400);
       expect(respond.status).toBe(400);
     });
@@ -1344,12 +1342,12 @@ describe('Questions Module', () => {
       expect(respond.body.code).toBe(200);
       expect(respond.body.data.users.length).toBe(5);
     });
-    it('should return QuestionIdNotFoundEroor', async () => {
+    it('should return QuestionNotFoundEroor', async () => {
       const respond = await request(app.getHttpServer())
         .get(`/questions/1919810/invitations/recommendations`)
         .set('Authorization', `Bearer ${TestToken}`)
         .query({ page_size: 5 });
-      expect(respond.body.message).toContain('QuestionIdNotFoundError');
+      expect(respond.body.message).toContain('QuestionNotFoundError');
       expect(respond.status).toBe(404);
       expect(respond.body.code).toBe(404);
     });
@@ -1441,12 +1439,12 @@ describe('Questions Module', () => {
       expect(respond.body.message).toMatch(/^AuthenticationRequiredError: /);
       expect(respond.body.code).toBe(401);
     });
-    it('should return QuestionIdNotFoundError', async () => {
+    it('should return QuestionNotFoundError', async () => {
       const respond = await request(app.getHttpServer())
         .put(`/questions/1919810/bounty`)
         .set('Authorization', `Bearer ${TestToken}`)
         .send({ bounty: 15 });
-      expect(respond.body.message).toMatch(/^QuestionIdNotFoundError: /);
+      expect(respond.body.message).toMatch(/^QuestionNotFoundError: /);
       expect(respond.body.code).toBe(404);
     });
   });
@@ -1466,13 +1464,13 @@ describe('Questions Module', () => {
         .send();
       expect(respond.body.data.question.accepted_answer.id).toBe(answerIds[0]);
     });
-    it('should return questionIdNotFoundError', async () => {
+    it('should return questionNotFoundError', async () => {
       const respond = await request(app.getHttpServer())
         .put(`/questions/1919810/acceptance`)
         .set('Authorization', `Bearer ${TestToken}`)
         .query({ answer_id: answerIds[0] });
       expect(respond.body.code).toBe(404);
-      expect(respond.body.message).toMatch(/^QuestionIdNotFoundError: /);
+      expect(respond.body.message).toMatch(/^QuestionNotFoundError: /);
     });
     it('should return answerIdNotFoundError', async () => {
       const respond = await request(app.getHttpServer())


### PR DESCRIPTION
fix #82 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Renamed error classes for improved clarity and consistency across the services. This includes changes in handling errors related to questions, comments, and groups not found, ensuring a more intuitive experience when encountering errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->