### PR TITLE
fix: transfer all Dto-name into RespondDto

### DIFF
--- a/src/answer/DTO/agree-answer.dto.ts
+++ b/src/answer/DTO/agree-answer.dto.ts
@@ -1,12 +1,6 @@
-import { IsNumber } from 'class-validator';
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
 
-export class AgreeAnswerRequestDto {
-  @IsNumber()
-  agree_type: number;
-}
-
-export class AgreeAnswerRespondDto extends BaseRespondDto {
+export class AgreeAnswerResponseDto extends BaseResponseDto {
   data: {
     agree_count: number;
   };

--- a/src/answer/DTO/create-answer.dto.ts
+++ b/src/answer/DTO/create-answer.dto.ts
@@ -1,6 +1,6 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
 
-export class CreateAnswerRespondDto extends BaseRespondDto {
+export class CreateAnswerResponseDto extends BaseResponseDto {
   data: {
     id: number;
   };

--- a/src/answer/DTO/get-answer-detail.dto.ts
+++ b/src/answer/DTO/get-answer-detail.dto.ts
@@ -1,8 +1,8 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
 import { QuestionDto } from '../../questions/DTO/question.dto';
 import { AnswerDto } from './answer.dto';
 
-export class GetAnswerDetailRespondDto extends BaseRespondDto {
+export class GetAnswerDetailResponseDto extends BaseResponseDto {
   data: {
     question: QuestionDto;
     answer: AnswerDto;

--- a/src/answer/DTO/get-answers.dto.ts
+++ b/src/answer/DTO/get-answers.dto.ts
@@ -1,10 +1,10 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
-import { PageRespondDto } from '../../common/DTO/page-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
+import { PageDto } from '../../common/DTO/page-response.dto';
 import { AnswerDto } from './answer.dto';
 
-export class GetAnswersRespondDto extends BaseRespondDto {
+export class GetAnswersResponseDto extends BaseResponseDto {
   data: {
     answers: AnswerDto[];
-    page: PageRespondDto;
+    page: PageDto;
   };
 }

--- a/src/answer/answer.controller.ts
+++ b/src/answer/answer.controller.ts
@@ -14,16 +14,16 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { AttitudeTypeDto } from '../attitude/DTO/attitude.dto';
-import { UpdateAttitudeRespondDto } from '../attitude/DTO/update-attitude.dto';
+import { UpdateAttitudeResponseDto } from '../attitude/DTO/update-attitude.dto';
 import { AuthService, AuthorizedAction } from '../auth/auth.service';
-import { BaseRespondDto } from '../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../common/DTO/base-response.dto';
 import { PageDto } from '../common/DTO/page.dto';
 import { BaseErrorExceptionFilter } from '../common/error/error-filter';
 import { TokenValidateInterceptor } from '../common/interceptor/token-validate.interceptor';
 import { QuestionsService } from '../questions/questions.service';
-import { CreateAnswerRespondDto } from './DTO/create-answer.dto';
-import { GetAnswerDetailRespondDto } from './DTO/get-answer-detail.dto';
-import { GetAnswersRespondDto } from './DTO/get-answers.dto';
+import { CreateAnswerResponseDto } from './DTO/create-answer.dto';
+import { GetAnswerDetailResponseDto } from './DTO/get-answer-detail.dto';
+import { GetAnswersResponseDto } from './DTO/get-answers.dto';
 import { UpdateAnswerRequestDto } from './DTO/update-answer.dto';
 import { AnswerService } from './answer.service';
 
@@ -40,11 +40,12 @@ export class AnswerController {
   @Get('/')
   async getQuestionAnswers(
     @Param('question_id') questionId: number,
-    @Query() { page_start: pageStart, page_size: pageSize }: PageDto,
+    @Query()
+    { page_start: pageStart, page_size: pageSize }: PageDto,
     @Headers('Authorization') auth: string | undefined,
     @Ip() ip: string,
     @Headers('User-Agent') userAgent: string,
-  ): Promise<GetAnswersRespondDto> {
+  ): Promise<GetAnswersResponseDto> {
     let userId: number | undefined;
     try {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -75,7 +76,7 @@ export class AnswerController {
     @Param('question_id', ParseIntPipe) questionId: number,
     @Body('content') content: string,
     @Headers('Authorization') auth: string | undefined,
-  ): Promise<CreateAnswerRespondDto> {
+  ): Promise<CreateAnswerResponseDto> {
     const userId = this.authService.verify(auth).userId;
     this.authService.audit(
       auth,
@@ -105,7 +106,7 @@ export class AnswerController {
     @Headers('Authorization') auth: string | undefined,
     @Ip() ip: string,
     @Headers('User-Agent') userAgent: string,
-  ): Promise<GetAnswerDetailRespondDto> {
+  ): Promise<GetAnswerDetailResponseDto> {
     let userId;
     try {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -142,7 +143,7 @@ export class AnswerController {
     @Param('answer_id', ParseIntPipe) answerId: number,
     @Body() { content }: UpdateAnswerRequestDto,
     @Headers('Authorization') auth: string | undefined,
-  ): Promise<BaseRespondDto> {
+  ): Promise<BaseResponseDto> {
     const userId = this.authService.verify(auth).userId;
     this.authService.audit(
       auth,
@@ -186,7 +187,7 @@ export class AnswerController {
     @Param('answer_id', ParseIntPipe) answerId: number,
     @Body() { attitude_type: attitudeType }: AttitudeTypeDto,
     @Headers('Authorization') auth: string | undefined,
-  ): Promise<UpdateAttitudeRespondDto> {
+  ): Promise<UpdateAttitudeResponseDto> {
     const userId = this.authService.verify(auth).userId;
     this.authService.audit(
       auth,
@@ -215,7 +216,7 @@ export class AnswerController {
     @Param('question_id', ParseIntPipe) questionId: number,
     @Param('answer_id', ParseIntPipe) answerId: number,
     @Headers('Authorization') auth: string | undefined,
-  ): Promise<BaseRespondDto> {
+  ): Promise<BaseResponseDto> {
     const userId = this.authService.verify(auth).userId;
     this.authService.audit(
       auth,

--- a/src/answer/answer.service.ts
+++ b/src/answer/answer.service.ts
@@ -11,7 +11,7 @@ import { AttitudeStateDto } from '../attitude/DTO/attitude-state.dto';
 import { AttitudeService } from '../attitude/attitude.service';
 import { CommentsService } from '../comments/comment.service';
 import { CommentableType } from '../comments/commentable.enum';
-import { PageRespondDto } from '../common/DTO/page-respond.dto';
+import { PageDto } from '../common/DTO/page-response.dto';
 import { PageHelper } from '../common/helper/page.helper';
 import { GroupsService } from '../groups/groups.service';
 import { QuestionNotFoundError } from '../questions/questions.error';
@@ -95,7 +95,7 @@ export class AnswerService {
     viewerId?: number,
     ip?: string,
     userAgent?: string,
-  ): Promise<[AnswerDto[], PageRespondDto]> {
+  ): Promise<[AnswerDto[], PageDto]> {
     if (!pageStart) {
       const currPage = await this.answerRepository.find({
         where: { questionId },
@@ -163,7 +163,7 @@ export class AnswerService {
     viewerId?: number,
     ip?: string,
     userAgent?: string,
-  ): Promise<[AnswerDto[], PageRespondDto]> {
+  ): Promise<[AnswerDto[], PageDto]> {
     if ((await this.usersService.isUserExists(userId)) == false)
       throw new UserIdNotFoundError(userId);
     if (!pageStart) {
@@ -447,7 +447,7 @@ export class AnswerService {
     viewerId?: number, // optional
     ip?: string, // optional
     userAgent?: string, // optional
-  ): Promise<[AnswerDto[], PageRespondDto]> {
+  ): Promise<[AnswerDto[], PageDto]> {
     if ((await this.usersService.isUserExists(userId)) == false)
       throw new UserIdNotFoundError(userId);
     if (!pageStart) {

--- a/src/attitude/DTO/update-attitude.dto.ts
+++ b/src/attitude/DTO/update-attitude.dto.ts
@@ -1,7 +1,7 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
 import { AttitudeStateDto } from './attitude-state.dto';
 
-export class UpdateAttitudeRespondDto extends BaseRespondDto {
+export class UpdateAttitudeResponseDto extends BaseResponseDto {
   data: {
     attitudes: AttitudeStateDto;
   };

--- a/src/avatars/DTO/upload-avatar.dto.ts
+++ b/src/avatars/DTO/upload-avatar.dto.ts
@@ -1,5 +1,5 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
-export class UploadAvatarRespondDto extends BaseRespondDto {
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
+export class UploadAvatarResponseDto extends BaseResponseDto {
   data: {
     avatarid: number;
   };

--- a/src/avatars/avatars.controller.ts
+++ b/src/avatars/avatars.controller.ts
@@ -19,7 +19,7 @@ import * as fs from 'fs';
 import { BaseErrorExceptionFilter } from '../common/error/error-filter';
 import { getFileHash, getFileMimeType } from '../common/helper/file.helper';
 import { TokenValidateInterceptor } from '../common/interceptor/token-validate.interceptor';
-import { UploadAvatarRespondDto } from './DTO/upload-avatar.dto';
+import { UploadAvatarResponseDto } from './DTO/upload-avatar.dto';
 import {
   CorrespondentFileNotExistError,
   InvalidAvatarTypeError,
@@ -38,7 +38,7 @@ export class AvatarsController {
   @UseInterceptors(FileInterceptor('avatar'))
   async createAvatar(
     @UploadedFile() file: Express.Multer.File,
-  ): Promise<UploadAvatarRespondDto> {
+  ): Promise<UploadAvatarResponseDto> {
     //const userid = this.authService.verify(auth).userId;
     const avatar = await this.avatarsService.save(file.path, file.filename);
     return {

--- a/src/comments/DTO/create-comment.dto.ts
+++ b/src/comments/DTO/create-comment.dto.ts
@@ -1,6 +1,6 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
 
-export class CreateCommentResponseDto extends BaseRespondDto {
+export class CreateCommentResponseDto extends BaseResponseDto {
   data: {
     id: number;
   };

--- a/src/comments/DTO/get-comment-detail.dto.ts
+++ b/src/comments/DTO/get-comment-detail.dto.ts
@@ -1,7 +1,7 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
 import { CommentDto } from './comment.dto';
 
-export class GetCommentDetailResponseDto extends BaseRespondDto {
+export class GetCommentDetailResponseDto extends BaseResponseDto {
   data: {
     comment: CommentDto;
   };

--- a/src/comments/DTO/get-comments.dto.ts
+++ b/src/comments/DTO/get-comments.dto.ts
@@ -1,10 +1,10 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
-import { PageRespondDto } from '../../common/DTO/page-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
+import { PageDto } from '../../common/DTO/page-response.dto';
 import { CommentDto } from './comment.dto';
 
-export class GetCommentsResponseDto extends BaseRespondDto {
+export class GetCommentsResponseDto extends BaseResponseDto {
   data: {
     comments: CommentDto[];
-    page: PageRespondDto;
+    page: PageDto;
   };
 }

--- a/src/comments/DTO/update-comment.dto.ts
+++ b/src/comments/DTO/update-comment.dto.ts
@@ -1,9 +1,6 @@
 import { IsNotEmpty } from 'class-validator';
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
 
 export class UpdateCommentDto {
   @IsNotEmpty()
   content: string;
 }
-
-export class UpdateCommentResponseDto extends BaseRespondDto {}

--- a/src/comments/comment.controller.ts
+++ b/src/comments/comment.controller.ts
@@ -14,18 +14,16 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { AttitudeTypeDto } from '../attitude/DTO/attitude.dto';
-import { UpdateAttitudeRespondDto } from '../attitude/DTO/update-attitude.dto';
+import { UpdateAttitudeResponseDto } from '../attitude/DTO/update-attitude.dto';
 import { AuthService, AuthorizedAction } from '../auth/auth.service';
+import { BaseResponseDto } from '../common/DTO/base-response.dto';
 import { PageDto } from '../common/DTO/page.dto';
 import { BaseErrorExceptionFilter } from '../common/error/error-filter';
 import { TokenValidateInterceptor } from '../common/interceptor/token-validate.interceptor';
 import { CreateCommentResponseDto } from './DTO/create-comment.dto';
 import { GetCommentDetailResponseDto } from './DTO/get-comment-detail.dto';
 import { GetCommentsResponseDto } from './DTO/get-comments.dto';
-import {
-  UpdateCommentDto,
-  UpdateCommentResponseDto,
-} from './DTO/update-comment.dto';
+import { UpdateCommentDto } from './DTO/update-comment.dto';
 import { CommentsService } from './comment.service';
 import { parseCommentable } from './commentable.enum';
 @Controller('/comments')
@@ -41,7 +39,8 @@ export class CommentsController {
   async getComments(
     @Param('commentableType') commentableType: string,
     @Param('commentableId', ParseIntPipe) commentableId: number,
-    @Query() { page_start: pageStart, page_size: pageSize }: PageDto,
+    @Query()
+    { page_start: pageStart, page_size: pageSize }: PageDto,
     @Headers('Authorization') auth: string | undefined,
     @Ip() ip: string,
     @Headers('User-Agent') userAgent: string,
@@ -80,7 +79,7 @@ export class CommentsController {
     @Param('commentId', ParseIntPipe) commentId: number,
     @Body() { attitude_type: attitudeType }: AttitudeTypeDto,
     @Headers('Authorization') auth: string | undefined,
-  ): Promise<UpdateAttitudeRespondDto> {
+  ): Promise<UpdateAttitudeResponseDto> {
     const userId = this.authService.verify(auth).userId;
     this.authService.audit(
       auth,
@@ -184,7 +183,7 @@ export class CommentsController {
     @Param('commentId', ParseIntPipe) commentId: number,
     @Body() { content }: UpdateCommentDto,
     @Headers('Authorization') auth: string | undefined,
-  ): Promise<UpdateCommentResponseDto> {
+  ): Promise<BaseResponseDto> {
     this.authService.audit(
       auth,
       AuthorizedAction.modify,

--- a/src/comments/comment.service.ts
+++ b/src/comments/comment.service.ts
@@ -5,7 +5,7 @@ import { LessThanOrEqual, MoreThan, Repository } from 'typeorm';
 import { AnswerService } from '../answer/answer.service';
 import { AttitudeStateDto } from '../attitude/DTO/attitude-state.dto';
 import { AttitudeService } from '../attitude/attitude.service';
-import { PageRespondDto } from '../common/DTO/page-respond.dto';
+import { PageDto } from '../common/DTO/page-response.dto';
 import { PageHelper } from '../common/helper/page.helper';
 import { PrismaService } from '../common/prisma/prisma.service';
 import { QuestionsService } from '../questions/questions.service';
@@ -150,7 +150,7 @@ export class CommentsService {
     viewerId?: number,
     ip?: string,
     userAgent?: string,
-  ): Promise<[CommentDto[], PageRespondDto]> {
+  ): Promise<[CommentDto[], PageDto]> {
     if (pageStart == undefined) {
       const comments = await this.commentRepository.find({
         where: {

--- a/src/common/DTO/base-response.dto.ts
+++ b/src/common/DTO/base-response.dto.ts
@@ -9,7 +9,7 @@
 
 import { IsInt, IsString } from 'class-validator';
 
-export class BaseRespondDto {
+export class BaseResponseDto {
   constructor(code: number, message: string) {
     this.code = code;
     this.message = message;

--- a/src/common/DTO/page-response.dto.ts
+++ b/src/common/DTO/page-response.dto.ts
@@ -8,7 +8,7 @@
 
 import { IsNumber } from 'class-validator';
 
-export class PageRespondDto {
+export class PageDto {
   @IsNumber()
   page_start: number;
 

--- a/src/common/helper/page.helper.ts
+++ b/src/common/helper/page.helper.ts
@@ -1,13 +1,13 @@
 /*
  *  Description: This file implements the PageHelper class.
- *               Its an utility class for generating the PageRespondDto data.
+ *               Its an utility class for generating the PageResponseDto data.
  *
  *  Author(s):
  *      Nictheboy Li    <nictheboy@outlook.com>
  *
  */
 
-import { PageRespondDto } from '../DTO/page-respond.dto';
+import { PageDto } from '../DTO/page-response.dto';
 
 export class PageHelper {
   // Used when you do
@@ -23,7 +23,7 @@ export class PageHelper {
     data: TData[],
     pageSize: number,
     idGetter: (item: TData) => number,
-  ): [TData[], PageRespondDto] {
+  ): [TData[], PageDto] {
     return PageHelper.PageInternal(data, pageSize, false, 0, idGetter);
   }
 
@@ -50,7 +50,7 @@ export class PageHelper {
     pageSize: number,
     idGetterPrev: (item: TPrev) => number,
     idGetter: (item: TData) => number,
-  ): [TData[], PageRespondDto] {
+  ): [TData[], PageDto] {
     let has_prev = false;
     let prev_start = 0;
     if (prev.length > 0) {
@@ -84,7 +84,7 @@ export class PageHelper {
     // Something like '() => { throw new TopicNotFoundError(pageStart); }'
     // If pageStart is not found in allData, this function will be called.
     errorIfNotFound?: (pageStart: number) => void,
-  ): [TData[], PageRespondDto] {
+  ): [TData[], PageDto] {
     if (pageStart == undefined) {
       const data = allData.slice(0, pageSize + 1);
       return PageHelper.PageStart(data, pageSize, idGetter);
@@ -109,7 +109,7 @@ export class PageHelper {
     hasPrev: boolean,
     prevStart: number,
     idGetter: (item: TData) => number,
-  ): [TData[], PageRespondDto] {
+  ): [TData[], PageDto] {
     if (data.length == 0 || pageSize < 0) {
       return [
         [],

--- a/src/groups/DTO/get-group-members.dto.ts
+++ b/src/groups/DTO/get-group-members.dto.ts
@@ -1,10 +1,10 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
-import { PageRespondDto } from '../../common/DTO/page-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
+import { PageDto } from '../../common/DTO/page-response.dto';
 import { UserDto } from '../../users/DTO/user.dto';
 
-export class GetGroupMembersRespondDto extends BaseRespondDto {
+export class GetGroupMembersResponseDto extends BaseResponseDto {
   data: {
     members: UserDto[];
-    page?: PageRespondDto;
+    page?: PageDto;
   };
 }

--- a/src/groups/DTO/get-group-questions.dto.ts
+++ b/src/groups/DTO/get-group-questions.dto.ts
@@ -1,7 +1,7 @@
-import { PageRespondDto } from '../../common/DTO/page-respond.dto';
+import { PageDto } from '../../common/DTO/page-response.dto';
 import { QuestionDto } from '../../questions/DTO/question.dto';
 
 export class GetGroupQuestionsResultDto {
   questions: QuestionDto[];
-  page: PageRespondDto;
+  page: PageDto;
 }

--- a/src/groups/DTO/get-groups.dto.ts
+++ b/src/groups/DTO/get-groups.dto.ts
@@ -1,10 +1,10 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
-import { PageRespondDto } from '../../common/DTO/page-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
+import { PageDto } from '../../common/DTO/page-response.dto';
 import { GroupDto } from './group.dto';
 
-export class GetGroupsRespondDto extends BaseRespondDto {
+export class GetGroupsResponseDto extends BaseResponseDto {
   data: {
     groups: GroupDto[];
-    page: PageRespondDto;
+    page: PageDto;
   };
 }

--- a/src/groups/DTO/get-members.dto.ts
+++ b/src/groups/DTO/get-members.dto.ts
@@ -1,10 +1,10 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
-import { PageRespondDto } from '../../common/DTO/page-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
+import { PageDto } from '../../common/DTO/page-response.dto';
 import { UserDto } from '../../users/DTO/user.dto';
 
-export class GetGroupMembersRespondDto extends BaseRespondDto {
+export class GetGroupMembersResponseDto extends BaseResponseDto {
   data: {
     members: UserDto[];
-    page: PageRespondDto;
+    page: PageDto;
   };
 }

--- a/src/groups/DTO/get-questions.dto.ts
+++ b/src/groups/DTO/get-questions.dto.ts
@@ -1,10 +1,10 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
-import { PageRespondDto } from '../../common/DTO/page-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
+import { PageDto } from '../../common/DTO/page-response.dto';
 import { QuestionDto } from '../../questions/DTO/question.dto';
 
-export class GetGroupQuestionsRespondDto extends BaseRespondDto {
+export class GetGroupQuestionsResponseDto extends BaseResponseDto {
   data: {
     questions: QuestionDto[];
-    page: PageRespondDto;
+    page: PageDto;
   };
 }

--- a/src/groups/DTO/group.dto.ts
+++ b/src/groups/DTO/group.dto.ts
@@ -1,4 +1,4 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
 import { UserDto } from '../../users/DTO/user.dto';
 
 export class GroupDto {
@@ -17,7 +17,7 @@ export class GroupDto {
   is_public: boolean;
 }
 
-export class GroupRespondDto extends BaseRespondDto {
+export class GroupResponseDto extends BaseResponseDto {
   data: {
     group: GroupDto;
   };

--- a/src/groups/DTO/join-group.dto.ts
+++ b/src/groups/DTO/join-group.dto.ts
@@ -1,5 +1,5 @@
 import { IsString } from 'class-validator';
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
 
 export class JoinGroupDto {
   @IsString()
@@ -12,6 +12,6 @@ export class JoinGroupResultDto {
   is_waiting: boolean;
 }
 
-export class JoinGroupRespondDto extends BaseRespondDto {
+export class JoinGroupResponseDto extends BaseResponseDto {
   data: JoinGroupResultDto;
 }

--- a/src/groups/DTO/quit-group.dto.ts
+++ b/src/groups/DTO/quit-group.dto.ts
@@ -1,6 +1,6 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
 
-export class QuitGroupRespondDto extends BaseRespondDto {
+export class QuitGroupResponseDto extends BaseResponseDto {
   data: {
     member_count: number;
   };

--- a/src/groups/DTO/update-group.dto.ts
+++ b/src/groups/DTO/update-group.dto.ts
@@ -1,5 +1,4 @@
 import { IsInt, IsString } from 'class-validator';
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
 
 export class UpdateGroupDto {
   @IsString()
@@ -13,5 +12,3 @@ export class UpdateGroupDto {
 
   // todo: add cover
 }
-
-export class UpdateGroupRespondDto extends BaseRespondDto {}

--- a/src/groups/groups.controller.ts
+++ b/src/groups/groups.controller.ts
@@ -22,17 +22,18 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { AuthService } from '../auth/auth.service';
+import { BaseResponseDto } from '../common/DTO/base-response.dto';
 import { GroupPageDto } from '../common/DTO/page.dto';
 import { BaseErrorExceptionFilter } from '../common/error/error-filter';
 import { TokenValidateInterceptor } from '../common/interceptor/token-validate.interceptor';
 import { CreateGroupDto } from './DTO/create-group.dto';
-import { GetGroupsRespondDto } from './DTO/get-groups.dto';
-import { GetGroupMembersRespondDto } from './DTO/get-members.dto';
-import { GetGroupQuestionsRespondDto } from './DTO/get-questions.dto';
-import { GroupRespondDto } from './DTO/group.dto';
-import { JoinGroupDto, JoinGroupRespondDto } from './DTO/join-group.dto';
-import { QuitGroupRespondDto } from './DTO/quit-group.dto';
-import { UpdateGroupDto, UpdateGroupRespondDto } from './DTO/update-group.dto';
+import { GetGroupsResponseDto } from './DTO/get-groups.dto';
+import { GetGroupMembersResponseDto } from './DTO/get-members.dto';
+import { GetGroupQuestionsResponseDto } from './DTO/get-questions.dto';
+import { GroupResponseDto } from './DTO/group.dto';
+import { JoinGroupDto, JoinGroupResponseDto } from './DTO/join-group.dto';
+import { QuitGroupResponseDto } from './DTO/quit-group.dto';
+import { UpdateGroupDto } from './DTO/update-group.dto';
 import { GroupsService } from './groups.service';
 
 @Controller('/groups')
@@ -48,7 +49,7 @@ export class GroupsController {
   async createGroup(
     @Body() { name, intro, avatarId }: CreateGroupDto,
     @Headers('Authorization') auth: string | undefined,
-  ): Promise<GroupRespondDto> {
+  ): Promise<GroupResponseDto> {
     const userId = this.authService.verify(auth).userId;
     const group = await this.groupsService.createGroup(
       name,
@@ -67,7 +68,7 @@ export class GroupsController {
   async getGroups(
     @Query() { q: key, page_start, page_size, type }: GroupPageDto,
     @Headers('Authorization') auth: string | undefined,
-  ): Promise<GetGroupsRespondDto> {
+  ): Promise<GetGroupsResponseDto> {
     let userId: number | undefined;
     try {
       userId = this.authService.verify(auth).userId;
@@ -95,7 +96,7 @@ export class GroupsController {
   async getGroupDetail(
     @Param('id', ParseIntPipe) id: number,
     @Headers('Authorization') auth: string | undefined,
-  ): Promise<GroupRespondDto> {
+  ): Promise<GroupResponseDto> {
     const userId = this.authService.verify(auth).userId;
     const group = await this.groupsService.getGroupDtoById(userId, id);
     return {
@@ -110,7 +111,7 @@ export class GroupsController {
     @Param('id', ParseIntPipe) id: number,
     @Headers('Authorization') auth: string | undefined,
     @Body() req: UpdateGroupDto,
-  ): Promise<UpdateGroupRespondDto> {
+  ): Promise<BaseResponseDto> {
     const userId = this.authService.verify(auth).userId;
     await this.groupsService.updateGroup(
       userId,
@@ -138,7 +139,7 @@ export class GroupsController {
   async getGroupMembers(
     @Param('id', ParseIntPipe) id: number,
     @Query() { page_start, page_size }: GroupPageDto,
-  ): Promise<GetGroupMembersRespondDto> {
+  ): Promise<GetGroupMembersResponseDto> {
     const [members, page] = await this.groupsService.getGroupMembers(
       id,
       page_start,
@@ -159,7 +160,7 @@ export class GroupsController {
     @Param('id', ParseIntPipe) groupId: number,
     @Body() { intro }: JoinGroupDto,
     @Headers('Authorization') auth: string | undefined,
-  ): Promise<JoinGroupRespondDto> {
+  ): Promise<JoinGroupResponseDto> {
     const userId = this.authService.verify(auth).userId;
     const joinResult = await this.groupsService.joinGroup(
       userId,
@@ -177,7 +178,7 @@ export class GroupsController {
   async quitGroup(
     @Param('id', ParseIntPipe) groupId: number,
     @Headers('Authorization') auth: string | undefined,
-  ): Promise<QuitGroupRespondDto> {
+  ): Promise<QuitGroupResponseDto> {
     const userId = this.authService.verify(auth).userId;
     const member_count = await this.groupsService.quitGroup(userId, groupId);
     return {
@@ -191,7 +192,7 @@ export class GroupsController {
   async getGroupQuestions(
     @Param('id', ParseIntPipe) id: number,
     @Query() { page_start, page_size }: GroupPageDto,
-  ): Promise<GetGroupQuestionsRespondDto> {
+  ): Promise<GetGroupQuestionsResponseDto> {
     const getGroupQuestionsResult = await this.groupsService.getGroupQuestions(
       id,
       page_start,

--- a/src/groups/groups.service.ts
+++ b/src/groups/groups.service.ts
@@ -13,7 +13,7 @@ import { In, LessThan, MoreThanOrEqual, Repository } from 'typeorm';
 import { AnswerService } from '../answer/answer.service';
 import { AvatarNotFoundError } from '../avatars/avatars.error';
 import { AvatarsService } from '../avatars/avatars.service';
-import { PageRespondDto } from '../common/DTO/page-respond.dto';
+import { PageDto } from '../common/DTO/page-response.dto';
 import { PageHelper } from '../common/helper/page.helper';
 import { QuestionNotFoundError } from '../questions/questions.error';
 import { QuestionsService } from '../questions/questions.service';
@@ -133,7 +133,7 @@ export class GroupsService {
     page_start_id: number | undefined,
     page_size: number,
     order_type: GroupQueryType,
-  ): Promise<[GroupDto[], PageRespondDto]> {
+  ): Promise<[GroupDto[], PageDto]> {
     let queryBuilder = this.groupsRepository.createQueryBuilder('group');
 
     if (keyword) {
@@ -447,7 +447,7 @@ export class GroupsService {
     groupId: number,
     firstMemberId: number | undefined,
     page_size: number,
-  ): Promise<[UserDto[], PageRespondDto]> {
+  ): Promise<[UserDto[], PageDto]> {
     if ((await this.groupsRepository.findOneBy({ id: groupId })) == undefined) {
       throw new GroupNotFoundError(groupId);
     }

--- a/src/materials/DTO/get-material.dto.ts
+++ b/src/materials/DTO/get-material.dto.ts
@@ -1,7 +1,7 @@
 import { Material } from '@prisma/client';
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
 
-export class GetMaterialRespondDto extends BaseRespondDto {
+export class GetMaterialResponseDto extends BaseResponseDto {
   data: {
     material: Material;
   };

--- a/src/materials/DTO/upload-material.dto.ts
+++ b/src/materials/DTO/upload-material.dto.ts
@@ -1,5 +1,5 @@
 import { IsIn, IsString } from 'class-validator';
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
 
 export class UploadMaterialRequestDto {
   @IsString()
@@ -7,7 +7,7 @@ export class UploadMaterialRequestDto {
   type: string;
 }
 
-export class UploadMaterialRespondDto extends BaseRespondDto {
+export class UploadMaterialResponseDto extends BaseResponseDto {
   data: {
     id: number;
   };

--- a/src/materials/materials.controller.ts
+++ b/src/materials/materials.controller.ts
@@ -18,10 +18,10 @@ import {
 import { FileInterceptor } from '@nestjs/platform-express';
 import { AuthService } from '../auth/auth.service';
 import { BaseErrorExceptionFilter } from '../common/error/error-filter';
-import { GetMaterialRespondDto } from './DTO/get-material.dto';
-import { UploadMaterialRespondDto } from './DTO/upload-material.dto';
-import { MaterialsService } from './materials.service';
+import { GetMaterialResponseDto } from './DTO/get-material.dto';
 import { MaterialTypeDto } from './DTO/material.dto';
+import { UploadMaterialResponseDto } from './DTO/upload-material.dto';
+import { MaterialsService } from './materials.service';
 
 @Controller('/materials')
 @UsePipes(new ValidationPipe())
@@ -38,7 +38,7 @@ export class MaterialsController {
     @Body() { type: materialType }: MaterialTypeDto,
     @UploadedFile() file: Express.Multer.File,
     @Headers('Authorization') auth: string | undefined,
-  ): Promise<UploadMaterialRespondDto> {
+  ): Promise<UploadMaterialResponseDto> {
     this.authService.verify(auth);
     const materialId = await this.materialsService.uploadMaterial(
       materialType,
@@ -58,7 +58,7 @@ export class MaterialsController {
     @Param('materialId', ParseIntPipe) id: number,
     @Query('fields', new ParseArrayPipe({ separator: ',', optional: true }))
     fields: string[] = ['meta', 'url'],
-  ): Promise<GetMaterialRespondDto> {
+  ): Promise<GetMaterialResponseDto> {
     const material = await this.materialsService.getMaterial(id, fields);
     return {
       code: 200,

--- a/src/questions/DTO/add-question.dto.ts
+++ b/src/questions/DTO/add-question.dto.ts
@@ -7,7 +7,7 @@ import {
   Max,
   Min,
 } from 'class-validator';
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
 import { BOUNTY_LIMIT } from '../questions.error';
 
 export class AddQuestionRequestDto {
@@ -36,7 +36,7 @@ export class AddQuestionRequestDto {
   bounty: number = 0;
 }
 
-export class AddQuestionResponseDto extends BaseRespondDto {
+export class AddQuestionResponseDto extends BaseResponseDto {
   data: {
     id: number;
   };

--- a/src/questions/DTO/follow-unfollow-question.dto.ts
+++ b/src/questions/DTO/follow-unfollow-question.dto.ts
@@ -1,12 +1,12 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
 
-export class FollowQuestionResponseDto extends BaseRespondDto {
+export class FollowQuestionResponseDto extends BaseResponseDto {
   data: {
     follow_count: number;
   };
 }
 
-export class UnfollowQuestionResponseDto extends BaseRespondDto {
+export class UnfollowQuestionResponseDto extends BaseResponseDto {
   data: {
     follow_count: number;
   };

--- a/src/questions/DTO/get-invitation-detail.dto.ts
+++ b/src/questions/DTO/get-invitation-detail.dto.ts
@@ -1,7 +1,7 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
 import { QuestionInvitationDto } from './question-invitation.dto';
 
-export class GetQuestionInvitationDetailResponseDto extends BaseRespondDto {
+export class GetQuestionInvitationDetailResponseDto extends BaseResponseDto {
   data: {
     invitation: QuestionInvitationDto;
   };

--- a/src/questions/DTO/get-question-follower.dto.ts
+++ b/src/questions/DTO/get-question-follower.dto.ts
@@ -1,10 +1,10 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
-import { PageRespondDto } from '../../common/DTO/page-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
+import { PageDto } from '../../common/DTO/page-response.dto';
 import { UserDto } from '../../users/DTO/user.dto';
 
-export class GetQuestionFollowerResponseDto extends BaseRespondDto {
+export class GetQuestionFollowerResponseDto extends BaseResponseDto {
   data: {
     users: UserDto[];
-    page: PageRespondDto;
+    page: PageDto;
   };
 }

--- a/src/questions/DTO/get-question-invitation.dto.ts
+++ b/src/questions/DTO/get-question-invitation.dto.ts
@@ -1,10 +1,10 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
-import { PageRespondDto } from '../../common/DTO/page-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
+import { PageDto } from '../../common/DTO/page-response.dto';
 import { QuestionInvitationDto } from './question-invitation.dto';
 
-export class GetQuestionInvitationsResponseDto extends BaseRespondDto {
+export class GetQuestionInvitationsResponseDto extends BaseResponseDto {
   data: {
     invitations: QuestionInvitationDto[];
-    page: PageRespondDto;
+    page: PageDto;
   };
 }

--- a/src/questions/DTO/get-question-recommendations.dto.ts
+++ b/src/questions/DTO/get-question-recommendations.dto.ts
@@ -1,7 +1,7 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
 import { UserDto } from '../../users/DTO/user.dto';
 
-export class GetQuestionRecommendationsRespondDto extends BaseRespondDto {
+export class GetQuestionRecommendationsResponseDto extends BaseResponseDto {
   data: {
     users: UserDto[];
   };

--- a/src/questions/DTO/get-question.dto.ts
+++ b/src/questions/DTO/get-question.dto.ts
@@ -1,7 +1,7 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
 import { QuestionDto } from './question.dto';
 
-export class GetQuestionResponseDto extends BaseRespondDto {
+export class GetQuestionResponseDto extends BaseResponseDto {
   data: {
     question: QuestionDto;
   };

--- a/src/questions/DTO/invite-user-answer.dto.ts
+++ b/src/questions/DTO/invite-user-answer.dto.ts
@@ -1,12 +1,12 @@
 import { IsInt } from 'class-validator';
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
 
 export class InviteUsersAnswerRequestDto {
   @IsInt()
   user_id: number;
 }
 
-export class InviteUsersAnswerResponseDto extends BaseRespondDto {
+export class InviteUsersAnswerResponseDto extends BaseResponseDto {
   data: {
     invitationId: number;
   };

--- a/src/questions/DTO/search-question.dto.ts
+++ b/src/questions/DTO/search-question.dto.ts
@@ -1,10 +1,10 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
-import { PageRespondDto } from '../../common/DTO/page-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
+import { PageDto } from '../../common/DTO/page-response.dto';
 import { QuestionDto } from './question.dto';
 
-export class SearchQuestionResponseDto extends BaseRespondDto {
+export class SearchQuestionResponseDto extends BaseResponseDto {
   data: {
     questions: QuestionDto[];
-    page: PageRespondDto;
+    page: PageDto;
   };
 }

--- a/src/questions/questions.controller.ts
+++ b/src/questions/questions.controller.ts
@@ -24,9 +24,9 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { AttitudeTypeDto } from '../attitude/DTO/attitude.dto';
-import { UpdateAttitudeRespondDto } from '../attitude/DTO/update-attitude.dto';
+import { UpdateAttitudeResponseDto } from '../attitude/DTO/update-attitude.dto';
 import { AuthService, AuthorizedAction } from '../auth/auth.service';
-import { BaseRespondDto } from '../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../common/DTO/base-response.dto';
 import { PageDto, PageWithKeywordDto } from '../common/DTO/page.dto';
 import { BaseErrorExceptionFilter } from '../common/error/error-filter';
 import { TokenValidateInterceptor } from '../common/interceptor/token-validate.interceptor';
@@ -46,7 +46,7 @@ import {
 import { GetQuestionInvitationDetailResponseDto } from './DTO/get-invitation-detail.dto';
 import { GetQuestionFollowerResponseDto } from './DTO/get-question-follower.dto';
 import { GetQuestionInvitationsResponseDto } from './DTO/get-question-invitation.dto';
-import { GetQuestionRecommendationsRespondDto } from './DTO/get-question-recommendations.dto';
+import { GetQuestionRecommendationsResponseDto } from './DTO/get-question-recommendations.dto';
 import { GetQuestionResponseDto } from './DTO/get-question.dto';
 import {
   InviteUsersAnswerRequestDto,
@@ -165,7 +165,7 @@ export class QuestionsController {
     @Param('id', ParseIntPipe) id: number,
     @Body() { title, content, type, topics }: UpdateQuestionRequestDto,
     @Headers('Authorization') auth: string | undefined,
-  ): Promise<BaseRespondDto> {
+  ): Promise<BaseResponseDto> {
     this.authService.audit(
       auth,
       AuthorizedAction.modify,
@@ -205,7 +205,8 @@ export class QuestionsController {
   @Get('/:id/followers')
   async getQuestionFollowers(
     @Param('id', ParseIntPipe) id: number,
-    @Query() { page_start: pageStart, page_size: pageSize }: PageDto,
+    @Query()
+    { page_start: pageStart, page_size: pageSize }: PageDto,
     @Headers('Authorization') auth: string | undefined,
     @Ip() ip: string,
     @Headers('User-Agent') userAgent: string,
@@ -286,7 +287,7 @@ export class QuestionsController {
     @Param('id', ParseIntPipe) questionId: number,
     @Body() { attitude_type: attitudeType }: AttitudeTypeDto,
     @Headers('Authorization') auth: string | undefined,
-  ): Promise<UpdateAttitudeRespondDto> {
+  ): Promise<UpdateAttitudeResponseDto> {
     const userId = this.authService.verify(auth).userId;
     this.authService.audit(
       auth,
@@ -312,7 +313,8 @@ export class QuestionsController {
   @Get('/:id/invitations')
   async getQuestionInvitations(
     @Param('id', ParseIntPipe) id: number,
-    @Query() { page_start: pageStart, page_size: pageSize }: PageDto,
+    @Query()
+    { page_start: pageStart, page_size: pageSize }: PageDto,
     @Query(
       'sort',
       new SnakeCaseToCamelCasePipe({ prefixIgnorePattern: '[+-]' }),
@@ -372,7 +374,7 @@ export class QuestionsController {
     @Param('id', ParseIntPipe) id: number,
     @Param('invitation_id', ParseIntPipe) invitationId: number,
     @Headers('Authorization') auth: string | undefined,
-  ): Promise<BaseRespondDto> {
+  ): Promise<BaseResponseDto> {
     this.authService.audit(
       auth,
       AuthorizedAction.delete,
@@ -395,7 +397,7 @@ export class QuestionsController {
     @Param('id', ParseIntPipe) id: number,
     @Query('page_size')
     pageSize: number,
-  ): Promise<GetQuestionRecommendationsRespondDto> {
+  ): Promise<GetQuestionRecommendationsResponseDto> {
     const users =
       await this.questionsService.getQuestionInvitationRecommendations(
         id,
@@ -433,7 +435,7 @@ export class QuestionsController {
     @Param('id', ParseIntPipe) id: number,
     @Headers('Authorization') auth: string | undefined,
     @Body() { bounty }: SetBountyDto,
-  ): Promise<BaseRespondDto> {
+  ): Promise<BaseResponseDto> {
     this.authService.audit(
       auth,
       AuthorizedAction.modify,
@@ -453,7 +455,7 @@ export class QuestionsController {
     @Param('id', ParseIntPipe) id: number,
     @Query('answer_id', ParseIntPipe) answer_id: number,
     @Headers('Authorization') auth: string | undefined,
-  ): Promise<BaseRespondDto> {
+  ): Promise<BaseResponseDto> {
     this.authService.audit(
       auth,
       AuthorizedAction.modify,

--- a/src/questions/questions.service.ts
+++ b/src/questions/questions.service.ts
@@ -21,7 +21,7 @@ import { AnswerService } from '../answer/answer.service';
 import { AttitudeStateDto } from '../attitude/DTO/attitude-state.dto';
 import { AttitudeService } from '../attitude/attitude.service';
 import { CommentableType } from '../comments/commentable.enum';
-import { PageRespondDto } from '../common/DTO/page-respond.dto';
+import { PageDto } from '../common/DTO/page-response.dto';
 import { PageHelper } from '../common/helper/page.helper';
 import {
   getCurrWhereBySort,
@@ -378,7 +378,7 @@ export class QuestionsService {
     searcherId?: number, // optional
     ip?: string, // optional
     userAgent?: string, // optional
-  ): Promise<[QuestionDto[], PageRespondDto]> {
+  ): Promise<[QuestionDto[], PageDto]> {
     const timeBegin = Date.now();
     const result = !keywords
       ? { hits: { hits: [] } }
@@ -583,7 +583,7 @@ export class QuestionsService {
     viewerId?: number, // optional
     ip?: string, // optional
     userAgent?: string, // optional
-  ): Promise<[QuestionDto[], PageRespondDto]> {
+  ): Promise<[QuestionDto[], PageDto]> {
     if ((await this.userService.isUserExists(followerId)) == false)
       throw new UserIdNotFoundError(followerId);
     if (firstQuestionId == undefined) {
@@ -638,7 +638,7 @@ export class QuestionsService {
     viewerId?: number, // optional
     ip?: string, // optional
     userAgent?: string, // optional
-  ): Promise<[UserDto[], PageRespondDto]> {
+  ): Promise<[UserDto[], PageDto]> {
     if (firstFollowerId == undefined) {
       const relations = await this.questionFollowRelationRepository.find({
         where: { questionId },
@@ -739,7 +739,7 @@ export class QuestionsService {
     sort: SortPattern,
     pageStart: number | undefined,
     pageSize: number | undefined = 20,
-  ): Promise<[QuestionInvitationDto[], PageRespondDto]> {
+  ): Promise<[QuestionInvitationDto[], PageDto]> {
     const record2dto = async (
       invitation: QuestionInvitationRelation,
     ): Promise<QuestionInvitationDto> => {
@@ -1010,7 +1010,7 @@ export class QuestionsService {
     viewerId?: number,
     userAgent?: string,
     ip?: string,
-  ): Promise<[QuestionDto[], PageRespondDto]> {
+  ): Promise<[QuestionDto[], PageDto]> {
     if ((await this.userService.isUserExists(userId)) == false)
       throw new UserIdNotFoundError(userId);
     if (!pageStart) {

--- a/src/topics/DTO/add-topic.dto.ts
+++ b/src/topics/DTO/add-topic.dto.ts
@@ -1,12 +1,12 @@
 import { IsString } from 'class-validator';
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
 
 export class AddTopicRequestDto {
   @IsString()
   name: string;
 }
 
-export class AddTopicResponseDto extends BaseRespondDto {
+export class AddTopicResponseDto extends BaseResponseDto {
   data: {
     id: number;
   };

--- a/src/topics/DTO/get-topic.dto.ts
+++ b/src/topics/DTO/get-topic.dto.ts
@@ -1,7 +1,7 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
 import { TopicDto } from './topic.dto';
 
-export class GetTopicResponseDto extends BaseRespondDto {
+export class GetTopicResponseDto extends BaseResponseDto {
   data: {
     topic: TopicDto;
   };

--- a/src/topics/DTO/search-topic.dto.ts
+++ b/src/topics/DTO/search-topic.dto.ts
@@ -1,10 +1,10 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
-import { PageRespondDto } from '../../common/DTO/page-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
+import { PageDto } from '../../common/DTO/page-response.dto';
 import { TopicDto } from './topic.dto';
 
-export class SearchTopicResponseDto extends BaseRespondDto {
+export class SearchTopicResponseDto extends BaseResponseDto {
   data: {
     topics: TopicDto[];
-    page: PageRespondDto;
+    page: PageDto;
   };
 }

--- a/src/topics/topics.service.ts
+++ b/src/topics/topics.service.ts
@@ -11,7 +11,7 @@ import { Injectable } from '@nestjs/common';
 import { ElasticsearchService } from '@nestjs/elasticsearch';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { PageRespondDto } from '../common/DTO/page-respond.dto';
+import { PageDto } from '../common/DTO/page-response.dto';
 import { PageHelper } from '../common/helper/page.helper';
 import { TopicDto } from './DTO/topic.dto';
 import { TopicAlreadyExistsError, TopicNotFoundError } from './topics.error';
@@ -56,7 +56,7 @@ export class TopicsService {
     searcherId?: number, // optional
     ip?: string, // optional
     userAgent?: string, // optional
-  ): Promise<[TopicDto[], PageRespondDto]> {
+  ): Promise<[TopicDto[], PageDto]> {
     const timeBegin = Date.now();
     const result = !keywords
       ? { hits: { hits: [] } }

--- a/src/users/DTO/follow-unfollow.dto.ts
+++ b/src/users/DTO/follow-unfollow.dto.ts
@@ -1,12 +1,12 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
 
-export class FollowRespondDto extends BaseRespondDto {
+export class FollowResponseDto extends BaseResponseDto {
   data: {
     follow_count: number;
   };
 }
 
-export class UnfollowRespondDto extends BaseRespondDto {
+export class UnfollowResponseDto extends BaseResponseDto {
   data: {
     follow_count: number;
   };

--- a/src/users/DTO/get-answered-answers.dto.ts
+++ b/src/users/DTO/get-answered-answers.dto.ts
@@ -1,10 +1,10 @@
 import { AnswerDto } from '../../answer/DTO/answer.dto';
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
-import { PageRespondDto } from '../../common/DTO/page-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
+import { PageDto } from '../../common/DTO/page-response.dto';
 
-export class GetAnsweredAnswersRespondDto extends BaseRespondDto {
+export class GetAnsweredAnswersResponseDto extends BaseResponseDto {
   data: {
     answers: AnswerDto[];
-    page: PageRespondDto;
+    page: PageDto;
   };
 }

--- a/src/users/DTO/get-asked-questions.dto.ts
+++ b/src/users/DTO/get-asked-questions.dto.ts
@@ -1,10 +1,10 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
-import { PageRespondDto } from '../../common/DTO/page-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
+import { PageDto } from '../../common/DTO/page-response.dto';
 import { QuestionDto } from '../../questions/DTO/question.dto';
 
-export class GetAskedQuestionsRespondDto extends BaseRespondDto {
+export class GetAskedQuestionsResponseDto extends BaseResponseDto {
   data: {
     questions: QuestionDto[];
-    page: PageRespondDto;
+    page: PageDto;
   };
 }

--- a/src/users/DTO/get-followed-questions.dto.ts
+++ b/src/users/DTO/get-followed-questions.dto.ts
@@ -1,10 +1,10 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
-import { PageRespondDto } from '../../common/DTO/page-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
+import { PageDto } from '../../common/DTO/page-response.dto';
 import { QuestionDto } from '../../questions/DTO/question.dto';
 
-export class GetFollowedQuestionsRespondDto extends BaseRespondDto {
+export class GetFollowedQuestionsResponseDto extends BaseResponseDto {
   data: {
     questions: QuestionDto[];
-    page: PageRespondDto;
+    page: PageDto;
   };
 }

--- a/src/users/DTO/get-followers.dto.ts
+++ b/src/users/DTO/get-followers.dto.ts
@@ -1,10 +1,10 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
-import { PageRespondDto } from '../../common/DTO/page-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
+import { PageDto } from '../../common/DTO/page-response.dto';
 import { UserDto } from './user.dto';
 
-export class GetFollowersRespondDto extends BaseRespondDto {
+export class GetFollowersResponseDto extends BaseResponseDto {
   data: {
     users: UserDto[];
-    page: PageRespondDto;
+    page: PageDto;
   };
 }

--- a/src/users/DTO/get-user.dto.ts
+++ b/src/users/DTO/get-user.dto.ts
@@ -1,7 +1,7 @@
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
 import { UserDto } from './user.dto';
 
-export class GetUserRespondDto extends BaseRespondDto {
+export class GetUserResponseDto extends BaseResponseDto {
   data: {
     user: UserDto;
   };

--- a/src/users/DTO/login.dto.ts
+++ b/src/users/DTO/login.dto.ts
@@ -1,5 +1,5 @@
 import { IsString } from 'class-validator';
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
 import { UserDto } from './user.dto';
 
 export class LoginRequestDto {
@@ -10,7 +10,7 @@ export class LoginRequestDto {
   password: string;
 }
 
-export class LoginRespondDto extends BaseRespondDto {
+export class LoginResponseDto extends BaseResponseDto {
   data: {
     accessToken: string;
     user: UserDto;

--- a/src/users/DTO/refresh-token.dto.ts
+++ b/src/users/DTO/refresh-token.dto.ts
@@ -1,3 +1,3 @@
-import { LoginRespondDto } from './login.dto';
+import { LoginResponseDto } from './login.dto';
 
-export class RefreshTokenRespondDto extends LoginRespondDto {}
+export class RefreshTokenResponseDto extends LoginResponseDto {}

--- a/src/users/DTO/register.dto.ts
+++ b/src/users/DTO/register.dto.ts
@@ -1,5 +1,5 @@
 import { IsString } from 'class-validator';
-import { LoginRespondDto } from './login.dto';
+import { LoginResponseDto } from './login.dto';
 
 export class RegisterRequestDto {
   @IsString()
@@ -18,4 +18,4 @@ export class RegisterRequestDto {
   emailCode: string;
 }
 
-export class RegisterResponseDto extends LoginRespondDto {}
+export class RegisterResponseDto extends LoginResponseDto {}

--- a/src/users/DTO/reset-password.dto.ts
+++ b/src/users/DTO/reset-password.dto.ts
@@ -1,12 +1,12 @@
 import { IsString } from 'class-validator';
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
 
 export class ResetPasswordRequestRequestDto {
   @IsString()
   email: string;
 }
 
-export class ResetPasswordRequestRespondDto extends BaseRespondDto {}
+export class ResetPasswordRequestDto extends BaseResponseDto {}
 
 export class ResetPasswordVerifyRequestDto {
   @IsString()
@@ -16,4 +16,4 @@ export class ResetPasswordVerifyRequestDto {
   new_password: string;
 }
 
-export class ResetPasswordVerifyRespondDto extends BaseRespondDto {}
+export class ResetPasswordVerifyResponseDto extends BaseResponseDto {}

--- a/src/users/DTO/send-email-verify-code.dto.ts
+++ b/src/users/DTO/send-email-verify-code.dto.ts
@@ -1,9 +1,9 @@
 import { IsString } from 'class-validator';
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
 
 export class SendEmailVerifyCodeRequestDto {
   @IsString()
   email: string;
 }
 
-export class SendEmailVerifyCodeResponseDto extends BaseRespondDto {}
+export class SendEmailVerifyCodeResponseDto extends BaseResponseDto {}

--- a/src/users/DTO/update-user.dto.ts
+++ b/src/users/DTO/update-user.dto.ts
@@ -1,5 +1,5 @@
 import { IsInt, IsString } from 'class-validator';
-import { BaseRespondDto } from '../../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../../common/DTO/base-response.dto';
 
 export class UpdateUserRequestDto {
   @IsString()
@@ -12,4 +12,4 @@ export class UpdateUserRequestDto {
   avatarId: number;
 }
 
-export class UpdateUserRespondDto extends BaseRespondDto {}
+export class UpdateUserResponseDto extends BaseResponseDto {}

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -31,7 +31,7 @@ import { AnswerService } from '../answer/answer.service';
 import { AuthenticationRequiredError } from '../auth/auth.error';
 import { AuthService, AuthorizedAction } from '../auth/auth.service';
 import { SessionService } from '../auth/session.service';
-import { BaseRespondDto } from '../common/DTO/base-respond.dto';
+import { BaseResponseDto } from '../common/DTO/base-response.dto';
 import { PageDto } from '../common/DTO/page.dto';
 import { BaseErrorExceptionFilter } from '../common/error/error-filter';
 import {
@@ -40,22 +40,22 @@ import {
 } from '../common/interceptor/token-validate.interceptor';
 import { QuestionsService } from '../questions/questions.service';
 import {
-  FollowRespondDto as FollowUserRespondDto,
-  UnfollowRespondDto as UnfollowUserRespondDto,
+  FollowResponseDto,
+  UnfollowResponseDto,
 } from './DTO/follow-unfollow.dto';
-import { GetAnsweredAnswersRespondDto } from './DTO/get-answered-answers.dto';
-import { GetAskedQuestionsRespondDto } from './DTO/get-asked-questions.dto';
-import { GetFollowedQuestionsRespondDto } from './DTO/get-followed-questions.dto';
-import { GetFollowersRespondDto } from './DTO/get-followers.dto';
-import { GetUserRespondDto } from './DTO/get-user.dto';
-import { LoginRequestDto, LoginRespondDto } from './DTO/login.dto';
-import { RefreshTokenRespondDto } from './DTO/refresh-token.dto';
+import { GetAnsweredAnswersResponseDto } from './DTO/get-answered-answers.dto';
+import { GetAskedQuestionsResponseDto } from './DTO/get-asked-questions.dto';
+import { GetFollowedQuestionsResponseDto } from './DTO/get-followed-questions.dto';
+import { GetFollowersResponseDto } from './DTO/get-followers.dto';
+import { GetUserResponseDto } from './DTO/get-user.dto';
+import { LoginRequestDto, LoginResponseDto } from './DTO/login.dto';
+import { RefreshTokenResponseDto } from './DTO/refresh-token.dto';
 import { RegisterRequestDto, RegisterResponseDto } from './DTO/register.dto';
 import {
+  ResetPasswordRequestDto,
   ResetPasswordRequestRequestDto,
-  ResetPasswordRequestRespondDto,
   ResetPasswordVerifyRequestDto,
-  ResetPasswordVerifyRespondDto,
+  ResetPasswordVerifyResponseDto,
 } from './DTO/reset-password.dto';
 import {
   SendEmailVerifyCodeRequestDto,
@@ -63,7 +63,7 @@ import {
 } from './DTO/send-email-verify-code.dto';
 import {
   UpdateUserRequestDto,
-  UpdateUserRespondDto,
+  UpdateUserResponseDto,
 } from './DTO/update-user.dto';
 import { UsersService } from './users.service';
 
@@ -161,7 +161,7 @@ export class UsersController {
     const newRefreshTokenExpire = new Date(
       this.authService.decode(newRefreshToken).validUntil,
     );
-    const data: LoginRespondDto = {
+    const data: LoginResponseDto = {
       code: 201,
       message: 'Login successfully.',
       data: {
@@ -210,7 +210,7 @@ export class UsersController {
       ip,
       userAgent,
     );
-    const data: RefreshTokenRespondDto = {
+    const data: RefreshTokenResponseDto = {
       code: 201,
       message: 'Refresh token successfully.',
       data: {
@@ -232,7 +232,7 @@ export class UsersController {
   @NoTokenValidate()
   async logout(
     @Headers('cookie') cookieHeader: string,
-  ): Promise<BaseRespondDto> {
+  ): Promise<BaseResponseDto> {
     if (cookieHeader == undefined) {
       throw new AuthenticationRequiredError();
     }
@@ -257,7 +257,7 @@ export class UsersController {
     @Body() { email }: ResetPasswordRequestRequestDto,
     @Ip() ip: string,
     @Headers('User-Agent') userAgent: string,
-  ): Promise<ResetPasswordRequestRespondDto> {
+  ): Promise<ResetPasswordRequestDto> {
     await this.usersService.sendResetPasswordEmail(email, ip, userAgent);
     return {
       code: 201,
@@ -271,7 +271,7 @@ export class UsersController {
     @Body() { token, new_password }: ResetPasswordVerifyRequestDto,
     @Ip() ip: string,
     @Headers('User-Agent') userAgent: string,
-  ): Promise<ResetPasswordVerifyRespondDto> {
+  ): Promise<ResetPasswordVerifyResponseDto> {
     await this.usersService.verifyAndResetPassword(
       token,
       new_password,
@@ -290,7 +290,7 @@ export class UsersController {
     @Headers('Authorization') auth: string | undefined,
     @Ip() ip: string,
     @Headers('User-Agent') userAgent: string,
-  ): Promise<GetUserRespondDto> {
+  ): Promise<GetUserResponseDto> {
     let viewerId: number | undefined;
     try {
       viewerId = this.authService.verify(auth).userId;
@@ -317,7 +317,7 @@ export class UsersController {
     @Param('id', ParseIntPipe) id: number,
     @Body() { nickname, intro, avatarId }: UpdateUserRequestDto,
     @Headers('Authorization') auth: string | undefined,
-  ): Promise<UpdateUserRespondDto> {
+  ): Promise<UpdateUserResponseDto> {
     this.authService.audit(
       auth,
       AuthorizedAction.modify,
@@ -336,7 +336,7 @@ export class UsersController {
   async followUser(
     @Param('id', ParseIntPipe) id: number,
     @Headers('Authorization') auth: string | undefined,
-  ): Promise<FollowUserRespondDto> {
+  ): Promise<FollowResponseDto> {
     const userId = this.authService.verify(auth).userId;
     this.authService.audit(
       auth,
@@ -359,7 +359,7 @@ export class UsersController {
   async unfollowUser(
     @Param('id', ParseIntPipe) id: number,
     @Headers('Authorization') auth: string | undefined,
-  ): Promise<UnfollowUserRespondDto> {
+  ): Promise<UnfollowResponseDto> {
     const userId = this.authService.verify(auth).userId;
     this.authService.audit(
       auth,
@@ -381,11 +381,12 @@ export class UsersController {
   @Get('/:id/followers')
   async getFollowers(
     @Param('id', ParseIntPipe) id: number,
-    @Query() { page_start: pageStart, page_size: pageSize }: PageDto,
+    @Query()
+    { page_start: pageStart, page_size: pageSize }: PageDto,
     @Headers('Authorization') auth: string | undefined,
     @Ip() ip: string,
     @Headers('User-Agent') userAgent: string,
-  ): Promise<GetFollowersRespondDto> {
+  ): Promise<GetFollowersResponseDto> {
     if (pageSize == undefined || pageSize == 0) pageSize = 20;
     // try get viewer id
     let viewerId: number | undefined;
@@ -415,11 +416,12 @@ export class UsersController {
   @Get('/:id/follow/users')
   async getFollowees(
     @Param('id', ParseIntPipe) id: number,
-    @Query() { page_start: pageStart, page_size: pageSize }: PageDto,
+    @Query()
+    { page_start: pageStart, page_size: pageSize }: PageDto,
     @Headers('Authorization') auth: string | undefined,
     @Ip() ip: string,
     @Headers('User-Agent') userAgent: string,
-  ): Promise<GetFollowersRespondDto> {
+  ): Promise<GetFollowersResponseDto> {
     if (pageSize == undefined || pageSize == 0) pageSize = 20;
     // try get viewer id
     let viewerId: number | undefined;
@@ -449,11 +451,12 @@ export class UsersController {
   @Get('/:id/questions')
   async getUserAskedQuestions(
     @Param('id', ParseIntPipe) userId: number,
-    @Query() { page_start: pageStart, page_size: pageSize }: PageDto,
+    @Query()
+    { page_start: pageStart, page_size: pageSize }: PageDto,
     @Headers('Authorization') auth: string | undefined,
     @Ip() ip: string,
     @Headers('User-Agent') userAgent: string,
-  ): Promise<GetAskedQuestionsRespondDto> {
+  ): Promise<GetAskedQuestionsResponseDto> {
     if (pageSize == undefined || pageSize == 0) pageSize = 20;
     // try get viewer id
     let viewerId: number | undefined;
@@ -484,11 +487,12 @@ export class UsersController {
   @UseInterceptors(ClassSerializerInterceptor)
   async getUserAnsweredAnswers(
     @Param('id', ParseIntPipe) userId: number,
-    @Query() { page_start: pageStart, page_size: pageSize }: PageDto,
+    @Query()
+    { page_start: pageStart, page_size: pageSize }: PageDto,
     @Headers('Authorization') auth: string | undefined,
     @Ip() ip: string,
     @Headers('User-Agent') userAgent: string,
-  ): Promise<GetAnsweredAnswersRespondDto> {
+  ): Promise<GetAnsweredAnswersResponseDto> {
     if (pageSize == undefined || pageSize == 0) pageSize = 20;
     // try get viewer id
     let viewerId: number | undefined;
@@ -519,11 +523,12 @@ export class UsersController {
   @Get('/:id/follow/questions')
   async getFollowedQuestions(
     @Param('id', ParseIntPipe) userId: number,
-    @Query() { page_start: pageStart, page_size: pageSize }: PageDto,
+    @Query()
+    { page_start: pageStart, page_size: pageSize }: PageDto,
     @Headers('Authorization') auth: string | undefined,
     @Ip() ip: string,
     @Headers('User-Agent') userAgent: string,
-  ): Promise<GetFollowedQuestionsRespondDto> {
+  ): Promise<GetFollowedQuestionsResponseDto> {
     if (pageSize == undefined || pageSize == 0) pageSize = 20;
     // try get viewer id
     let viewerId: number | undefined;

--- a/src/users/users.service.ts
+++ b/src/users/users.service.ts
@@ -21,7 +21,7 @@ import {
 } from '../auth/auth.service';
 import { SessionService } from '../auth/session.service';
 import { AvatarsService } from '../avatars/avatars.service';
-import { PageRespondDto } from '../common/DTO/page-respond.dto';
+import { PageDto } from '../common/DTO/page-response.dto';
 import { PageHelper } from '../common/helper/page.helper';
 import { PrismaService } from '../common/prisma/prisma.service';
 import { QuestionsService } from '../questions/questions.service';
@@ -667,7 +667,7 @@ export class UsersService {
     viewerId?: number, // optional
     ip?: string, // optional
     userAgent?: string, // optional
-  ): Promise<[UserDto[], PageRespondDto]> {
+  ): Promise<[UserDto[], PageDto]> {
     if (firstFollowerId == undefined) {
       const relations = await this.userFollowingRepository.find({
         where: { followeeId: followeeId },
@@ -720,7 +720,7 @@ export class UsersService {
     viewerId?: number, // optional
     ip?: string, // optional
     userAgent?: string, // optional
-  ): Promise<[UserDto[], PageRespondDto]> {
+  ): Promise<[UserDto[], PageDto]> {
     if (firstFolloweeId == undefined) {
       const relations = await this.userFollowingRepository.find({
         where: { followerId: followerId },


### PR DESCRIPTION
fix #142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `data` field for `agree_count` in responses related to agreeing with answers.
- **Refactor**
	- Unified DTO naming conventions across the platform, transitioning from `Respond` to `Response` terminology.
	- Updated DTO structures and imports to enhance consistency and clarity in user interactions, including changes in question, comment, group, material, and user-related functionalities.
- **Bug Fixes**
	- Corrected inconsistencies in naming and type declarations across various features, ensuring a smoother user experience.
- **Documentation**
	- Adjustments in method signatures and DTO imports reflect a more intuitive and consistent documentation for developers and end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->