### PR TITLE
Fix: authentication required to GET avatars' default image

### DIFF
--- a/src/avatars/avatars.controller.ts
+++ b/src/avatars/avatars.controller.ts
@@ -47,11 +47,10 @@ export class AvatarsController {
   }
 
   @Get('/default')
-  @Guard('query-default', 'avatar')
+  @NoAuth()
   async getDefaultAvatar(
     @Headers('If-None-Match') ifNoneMatch: string,
     @Res({ passthrough: true }) res: Response,
-    @Headers('Authorization') @AuthToken() auth: string,
   ) {
     const defaultAvatarId = await this.avatarsService.getDefaultAvatarId();
     const avatarPath = await this.avatarsService.getAvatarPath(defaultAvatarId);
@@ -85,7 +84,6 @@ export class AvatarsController {
     @Headers('If-None-Match') ifNoneMatch: string,
     @Param('id', ParseIntPipe) @ResourceId() id: number,
     @Res({ passthrough: true }) res: Response,
-    @Headers('Authorization') @AuthToken() auth: string,
   ) {
     const avatarPath = await this.avatarsService.getAvatarPath(id);
     if (!fs.existsSync(avatarPath)) {

--- a/src/users/role-permission.service.ts
+++ b/src/users/role-permission.service.ts
@@ -140,7 +140,7 @@ export class RolePermissionService {
           },
         },
         {
-          authorizedActions: ['create', 'query-default', 'enumerate'],
+          authorizedActions: ['create', 'enumerate'],
           authorizedResource: {
             ownedByUser: undefined,
             types: ['avatar'],

--- a/test/avatars.e2e-spec.ts
+++ b/test/avatars.e2e-spec.ts
@@ -92,7 +92,6 @@ describe('Avatar Module', () => {
       const avatarId = AvatarId;
       const respond = await request(app.getHttpServer())
         .get(`/avatars/${avatarId}`)
-        .set('Authorization', `Bearer ${TestToken}`)
         .send()
         .responseType('blob');
       expect(respond.status).toBe(200);
@@ -106,25 +105,16 @@ describe('Avatar Module', () => {
     it('should return AvatarNotFoundError when an avatar is not found', async () => {
       const respond = await request(app.getHttpServer())
         .get('/avatars/1000')
-        .set('Authorization', `Bearer ${TestToken}`)
         .send();
       expect(respond.body.message).toMatch(/^AvatarNotFoundError: /);
       expect(respond.status).toBe(404);
     });
-    // it('should return AuthenticationRequiredError', async () => {
-    //   const respond = await request(app.getHttpServer())
-    //     .get(`/avatars/${AvatarId}`)
-    //     .send();
-    //   expect(respond.body.message).toMatch(/^AuthenticationRequiredError: /);
-    //   expect(respond.status).toBe(401);
-    // });
-  });
-  describe('get default avatar', () => {
-    it('should get default avatar', async () => {
+    it('should get avatar without authentication', async () => {
+      const avatarId = AvatarId;
       const respond = await request(app.getHttpServer())
-        .get('/avatars/default')
-        .set('Authorization', `Bearer ${TestToken}`)
-        .send();
+        .get(`/avatars/${avatarId}`)
+        .send()
+        .responseType('blob');
       expect(respond.status).toBe(200);
       expect(respond.headers['cache-control']).toContain('max-age');
       expect(respond.headers['content-type']).toMatch(/image\/.*/);
@@ -133,12 +123,19 @@ describe('Avatar Module', () => {
       expect(respond.headers['etag']).toBeDefined();
       expect(respond.headers['last-modified']).toBeDefined();
     });
-    it('should return AuthenticationRequiredError', async () => {
-      const respond = await request(app.getHttpServer()).get(
-        '/avatars/default',
-      );
-      expect(respond.body.message).toMatch(/^AuthenticationRequiredError: /);
-      expect(respond.status).toBe(401);
+  });
+  describe('get default avatar', () => {
+    it('should get default avatar', async () => {
+      const respond = await request(app.getHttpServer())
+        .get('/avatars/default')
+        .send();
+      expect(respond.status).toBe(200);
+      expect(respond.headers['cache-control']).toContain('max-age');
+      expect(respond.headers['content-type']).toMatch(/image\/.*/);
+      expect(respond.headers['content-disposition']).toContain('inline');
+      expect(respond.headers['content-length']).toBeDefined();
+      expect(respond.headers['etag']).toBeDefined();
+      expect(respond.headers['last-modified']).toBeDefined();
     });
   });
   describe('get pre available avatarIds', () => {


### PR DESCRIPTION
Fixes #299

Remove authentication requirement for getting default avatar image.

* **AvatarsController**:
  - Remove `@Guard('query-default', 'avatar')` decorator from `getDefaultAvatar` method.
  - Add `@NoAuth()` decorator to `getDefaultAvatar` method.
  - Remove `@Headers('Authorization') @AuthToken() auth: string` parameter from `getDefaultAvatar` method.
* **Tests**:
  - Remove authentication requirement for the test case that gets the default avatar image.
  - Update the test case to reflect the change in the `getDefaultAvatar` method.
  - Add a test case to validate that authentication is not required for `getAvatar`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SageSeekerSociety/cheese-backend/issues/299?shareId=9e4741a5-cc5f-481d-974e-24c4dc3ee42a).