### PR TITLE
feat(db): add passkey and two-factor authentication migration

### DIFF
--- a/prisma/migrations/20250219083432_add_passkey_and_2fa/migration.sql
+++ b/prisma/migrations/20250219083432_add_passkey_and_2fa/migration.sql
@@ -1,0 +1,43 @@
+-- AlterTable
+ALTER TABLE "user" ADD COLUMN     "totp_always_required" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "totp_enabled" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "totp_secret" VARCHAR(64);
+
+-- CreateTable
+CREATE TABLE "user_backup_code" (
+    "id" SERIAL NOT NULL,
+    "user_id" INTEGER NOT NULL,
+    "code_hash" VARCHAR(128) NOT NULL,
+    "used" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "user_backup_code_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "passkey" (
+    "id" SERIAL NOT NULL,
+    "credential_id" TEXT NOT NULL,
+    "public_key" BYTEA NOT NULL,
+    "counter" INTEGER NOT NULL,
+    "device_type" TEXT NOT NULL,
+    "backed_up" BOOLEAN NOT NULL,
+    "transports" TEXT,
+    "user_id" INTEGER NOT NULL,
+    "created_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PK_passkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "IDX_user_backup_code_user_id" ON "user_backup_code"("user_id");
+
+-- CreateIndex
+CREATE INDEX "IDX_passkey_user_id" ON "passkey"("user_id");
+
+-- AddForeignKey
+ALTER TABLE "user_backup_code" ADD CONSTRAINT "user_backup_code_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "passkey" ADD CONSTRAINT "passkey_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE RESTRICT ON UPDATE CASCADE;


### PR DESCRIPTION
# Add Missing Migration SQL for 2FA Implementation

## Background
In the previous PR (#382) that implemented TOTP-based two-factor authentication, the database migration SQL files were inadvertently omitted. This PR adds the necessary migration scripts.

## Changes

### Database Schema Changes
- Add `totp_secret` column (VARCHAR(64)) to `user` table
- Add `totp_enabled` boolean column to `user` table
- Add `totp_always_required` boolean column to `user` table
- Create new `user_backup_code` table for 2FA backup codes
- Create new `passkey` table for passkey

### Migration Files Added
- Add forward migration SQL for 2FA-related schema changes